### PR TITLE
fix: convert to webp

### DIFF
--- a/neonize/client.py
+++ b/neonize/client.py
@@ -769,15 +769,15 @@ class NewClient:
             )
             io_save.seek(0)
         else:
-            with FFmpeg(sticker) as ffmpeg:
+            with BytesIO(sticker) as img_io:
                 animated = True
-                sticker = ffmpeg.cv_to_webp()
-                io_save = BytesIO(sticker)
-                img = Image.open(io_save)
-                io_save.seek(0)
+                img = Image.open(img_io)
+                io_save = BytesIO()
                 img.save(
                     io_save, format="webp", exif=add_exif(name, packname), save_all=True
                 )
+                io_save.seek(0)
+                io_save.read()
         upload = self.upload(io_save.getvalue())
         message = Message(
             stickerMessage=StickerMessage(


### PR DESCRIPTION
i have run on platform windows and get trouble with function build_sticker_message() with error output : 
 File "C:\Users\Zaa\project\bot-wa\env\Lib\site-packages\neonize\client.py", line 772, in build_sticker_message
    img = Image.open(io_save)
          ^^^^^^^^^^^^^^^^^^^
  File "C:\Users\Zaa\project\bot-wa\env\Lib\site-packages\PIL\Image.py", line 3498, in open
    raise UnidentifiedImageError(msg)
PIL.UnidentifiedImageError: cannot identify image file <_io.BytesIO object at 0x00000256C2D5D580>

code : 
with FFmpeg(sticker) as ffmpeg:
                animated = True
                sticker = ffmpeg.cv_to_webp()
                io_save = BytesIO(sticker)
                img = Image.open(io_save)
                io_save.seek(0)
                img.save(
                    io_save, format="webp", exif=add_exif(name, packname), save_all=True
                )

then i changed the function to cv_to_webp() with the new code : 
with BytesIO(sticker) as img_io:
                animated = True
                img = Image.open(img_io)
                io_save = BytesIO()
                img.save(
                    io_save, format="webp", exif=add_exif(name, packname), save_all=True
                )
                io_save.seek(0)
                io_save.read()


https://stackoverflow.com/questions/31077366/pil-cannot-identify-image-file-for-io-bytesio-object                