### PR TITLE
Fix: logical bug. if no JID provided getFirstDevice instead of creati…

### DIFF
--- a/goneonize/main.go
+++ b/goneonize/main.go
@@ -159,7 +159,7 @@ func Neonize(db *C.char, id *C.char, JIDByte *C.uchar, JIDSize C.int, logLevel *
 		}
 		deviceStore, err_device = container.GetDevice(utils.DecodeJidProto(&JID))
 	} else {
-		deviceStore, err_device = container.NewDevice(), nil
+		deviceStore, err_device = container.GetFirstDevice(), nil
 	}
 	if err_device != nil {
 		panic(err)


### PR DESCRIPTION
There is a logical bug in the previous implementation. If no JID was provided when initializing Neonize instance, get the first device, which creates a new device if none existed, instead of creating a new one directly.