### PR TITLE
fix for: RuntimeWarning: coroutine 'to_thread' was never awaited

### DIFF
--- a/neonize/aioze/client.py
+++ b/neonize/aioze/client.py
@@ -2716,11 +2716,11 @@ class NewAClient:
             0,
         )
 
-    def disconnect(self) -> None:
+    async def disconnect(self) -> None:
         """
         Disconnect the client
         """
-        self.__client.Disconnect(self.uuid)
+        await self.__client.Disconnect(self.uuid)
 
 
 class ClientFactory:


### PR DESCRIPTION
Made aioze.client.disconnect awaitable