### PR TITLE
Use an event loop for both client and event_handler

### DIFF
--- a/examples/async_basic.py
+++ b/examples/async_basic.py
@@ -331,6 +331,10 @@ async def PairStatusMessage(_: NewAClient, message: PairStatusEv):
     log.info(f"logged as {message.ID.User}")
 
 
+async def connect():
+    await client.connect()
+    # Do something else
+    await client.idle() # Necessary to keep receiving events 
+
 if __name__ == "__main__":
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(client.connect())
+    client.loop.run_until_complete(connect())

--- a/examples/async_oneshot.py
+++ b/examples/async_oneshot.py
@@ -1,0 +1,40 @@
+import asyncio
+import logging
+import signal
+import sys
+import traceback
+from neonize.aioze.client import NewAClient
+from neonize.events import ConnectedEv
+from neonize.utils import jid, log
+
+sys.path.insert(0, os.getcwd())
+
+client = NewAClient("db.sqlite3")
+log.setLevel(logging.DEBUG)
+
+
+async def on_exit():
+    await client.stop()
+
+
+async def greet():
+    for signame in {"SIGINT", "SIGTERM", "SIGABRT"}:
+        client.loop.add_signal_handler(
+            getattr(signal, signame),
+            lambda: asyncio.create_task(on_exit()),
+        )
+    await client.connect()
+    while not client.connected: # Do not rely on this to detect if client is still connected 
+        await asyncio.sleep(0.1)
+    await client.send_message(
+        jid.build_jid("123456789"),
+        "Hey There!",
+    )
+    await client.stop()
+
+
+try:
+    if __name__ == "__main__":
+        client.loop.run_until_complete(greet())
+except Exception:
+    traceback.print_exc()

--- a/examples/multisession_async.py
+++ b/examples/multisession_async.py
@@ -315,8 +315,11 @@ async def handler(client: NewAClient, message: MessageEv):
 async def PairStatusMessage(_: NewAClient, message: PairStatusEv):
     log.info(f"logged as {message.ID.User}")
 
+async def run_factory():
+    await client_factory.run()
+    # Do something else
+    await client_factory.idle_all()
 
 if __name__ == "__main__":
     # all created clients will be automatically logged in and receive all events
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(client_factory.run())
+    client.loop.run_until_complete(run_factory())

--- a/neonize/aioze/events.py
+++ b/neonize/aioze/events.py
@@ -128,6 +128,12 @@ class Event:
         # print("key", code, "uuid", uuid, "size", size)
         # print(f"Executing function for event code {ctypes.string_at(code, size)} with UUID {uuid}")
         message = INT_TO_EVENT[code].FromString(ctypes.string_at(binary, size))
+
+        if code == 0:
+            self.client.me = message
+            return
+        elif code == 3:
+            self.client.connected = True
         # loop = asyncio.new_event_loop()
         # loop.run_until_complete(
         #     self.list_func[code](self.client, message)
@@ -235,7 +241,7 @@ class EventsManager:
         return callback
 
 
-threading.Thread(
-    target=event_global_loop.run_forever,
-    daemon=True,
-).start()
+#threading.Thread(
+#    target=event_global_loop.run_forever,
+#    daemon=True,
+#).start()

--- a/neonize/client.py
+++ b/neonize/client.py
@@ -377,6 +377,8 @@ class NewClient:
         self.qr = self.event.qr
         self.contact = ContactStore(self.uuid)
         self.chat_settings = ChatSettingsStore(self.uuid)
+        self.connected = False
+        self.me = None
         log.debug("🔨 Creating a NewClient instance")
 
     def __onLoginStatus(self, s: str):

--- a/neonize/events.py
+++ b/neonize/events.py
@@ -7,6 +7,7 @@ import segno
 from typing import TypeVar, Type, Callable, TYPE_CHECKING, Dict
 from google.protobuf.message import Message
 from threading import Event as EventThread
+from .proto.Neonize_pb2 import Device
 from .proto.Neonize_pb2 import (
     QR as QREv,
     PairStatus as PairStatusEv,
@@ -55,6 +56,7 @@ if TYPE_CHECKING:
     from .client import NewClient, ClientFactory
 EventType = TypeVar("EventType", bound=Message)
 EVENT_TO_INT: Dict[Type[Message], int] = {
+    Device: 0,
     QREv: 1,
     PairStatusEv: 2,
     ConnectedEv: 3,
@@ -151,6 +153,11 @@ class Event:
         if code not in INT_TO_EVENT:
             raise UnsupportedEvent()
         message = INT_TO_EVENT[code].FromString(ctypes.string_at(binary, size))
+        if code == 0:
+            self.client.me = message
+            return
+        elif code == 3:
+            self.client.connected = True
         self.list_func[code](self.client, message)
 
     def __onqr(self, _: NewClient, data_qr: bytes):


### PR DESCRIPTION
Asyncio Loop is @ client.loop
client.idle() has to be called to block the loop
Above applies to client_factory (See updated examples) but hasn't been tested 
client.connected can be relied on to quickly check if client has emitted a connected event
client.me has device info on connection 
Properly fixed the issue with client.pairphone not emitting a connected event 

#100 Added one_shot messages to examples 

@krypton-byte do I need to actually wait if store isn't at the callback here? https://github.com/Nubuki-all/neonize/blob/71f20366340653efed84d2e7ac7ebddd358de95b/goneonize/main.go#L2124