### PR TITLE
fix: free C strings leaked across the Go/Python FFI boundary

### DIFF
--- a/goneonize/main.go
+++ b/goneonize/main.go
@@ -2458,3 +2458,16 @@ func FreeBytesStruct(bytesReturn *C.struct_BytesReturn) {
 	}
 	C.free(unsafe.Pointer(bytesReturn))
 }
+
+// FreeString releases a C string returned to Python by a function whose
+// result is a *C.char (allocated by Go's C.CString). The Python side declares
+// such functions restype = c_void_p and calls this from a ctypes errcheck hook
+// once the string has been copied; without it the allocation is leaked, since
+// a c_char_p restype would discard the pointer.
+//
+//export FreeString
+func FreeString(str *C.char) {
+	if str != nil {
+		C.free(unsafe.Pointer(str))
+	}
+}

--- a/neonize/_binder.py
+++ b/neonize/_binder.py
@@ -66,7 +66,7 @@ if not os.environ.get("SPHINX"):
         ctypes.c_char_p,
         ctypes.c_int,
     ]
-    gocode.Neonize.restype = ctypes.c_char_p
+    gocode.Neonize.restype = ctypes.c_void_p
     gocode.GetLIDFromPN.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
     gocode.GetLIDFromPN.restype = ctypes.POINTER(Bytes)
     gocode.GetPNFromLID.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
@@ -130,14 +130,14 @@ if not os.environ.get("SPHINX"):
     ]
     gocode.SetProfilePhoto.restype = ctypes.POINTER(Bytes)
     gocode.LeaveGroup.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
-    gocode.LeaveGroup.restype = ctypes.c_char_p
+    gocode.LeaveGroup.restype = ctypes.c_void_p
     gocode.SetGroupName.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
         ctypes.c_int,
         ctypes.c_char_p,
     ]
-    gocode.SetGroupName.restype = ctypes.c_char_p
+    gocode.SetGroupName.restype = ctypes.c_void_p
     gocode.GetGroupInviteLink.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
@@ -162,7 +162,7 @@ if not os.environ.get("SPHINX"):
         ctypes.c_int,
         ctypes.c_int,
     ]
-    gocode.SendChatPresence.restype = ctypes.c_char_p
+    gocode.SendChatPresence.restype = ctypes.c_void_p
     gocode.BuildRevoke.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
@@ -175,7 +175,7 @@ if not os.environ.get("SPHINX"):
     gocode.CreateGroup.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
     gocode.CreateGroup.restype = ctypes.POINTER(Bytes)
     gocode.GenerateMessageID.argtypes = [ctypes.c_char_p]
-    gocode.GenerateMessageID.restype = ctypes.c_char_p
+    gocode.GenerateMessageID.restype = ctypes.c_void_p
     gocode.IsOnWhatsApp.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
     gocode.IsOnWhatsApp.restype = ctypes.POINTER(Bytes)
     gocode.IsConnected.argtypes = [ctypes.c_char_p]
@@ -215,7 +215,7 @@ if not os.environ.get("SPHINX"):
     gocode.CreateNewsletter.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
     gocode.CreateNewsletter.restype = ctypes.POINTER(Bytes)
     gocode.FollowNewsletter.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
-    gocode.FollowNewsletter.restype = ctypes.c_char_p
+    gocode.FollowNewsletter.restype = ctypes.c_void_p
     gocode.GetBlocklist.argtypes = [ctypes.c_char_p]
     gocode.GetBlocklist.restype = ctypes.POINTER(Bytes)
     gocode.GetContactQRLink.argtypes = [ctypes.c_char_p, ctypes.c_bool]
@@ -294,7 +294,7 @@ if not os.environ.get("SPHINX"):
         ctypes.c_char_p,
         ctypes.c_int,
     ]
-    gocode.JoinGroupWithInvite.restype = ctypes.c_char_p
+    gocode.JoinGroupWithInvite.restype = ctypes.c_void_p
     gocode.LinkGroup.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
@@ -302,9 +302,9 @@ if not os.environ.get("SPHINX"):
         ctypes.c_char_p,
         ctypes.c_int,
     ]
-    gocode.LinkGroup.restype = ctypes.POINTER(Bytes)
+    gocode.LinkGroup.restype = ctypes.c_void_p
     gocode.Logout.argtypes = [ctypes.c_char_p]
-    gocode.Logout.restype = ctypes.c_char_p
+    gocode.Logout.restype = ctypes.c_void_p
     gocode.MarkRead.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
@@ -315,7 +315,7 @@ if not os.environ.get("SPHINX"):
         ctypes.c_int,
         ctypes.c_char_p,
     ]
-    gocode.MarkRead.restype = ctypes.c_char_p
+    gocode.MarkRead.restype = ctypes.c_void_p
     gocode.NewsletterMarkViewed.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
@@ -323,7 +323,7 @@ if not os.environ.get("SPHINX"):
         ctypes.c_char_p,
         ctypes.c_int,
     ]
-    gocode.NewsletterMarkViewed.restype = ctypes.c_char_p
+    gocode.NewsletterMarkViewed.restype = ctypes.c_void_p
     gocode.NewsletterSendReaction.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
@@ -332,7 +332,7 @@ if not os.environ.get("SPHINX"):
         ctypes.c_char_p,
         ctypes.c_char_p,
     ]
-    gocode.NewsletterSendReaction.restype = ctypes.c_char_p
+    gocode.NewsletterSendReaction.restype = ctypes.c_void_p
     gocode.NewsletterSubscribeLiveUpdates.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
@@ -345,7 +345,7 @@ if not os.environ.get("SPHINX"):
         ctypes.c_int,
         ctypes.c_bool,
     ]
-    gocode.NewsletterToggleMute.restype = ctypes.c_char_p
+    gocode.NewsletterToggleMute.restype = ctypes.c_void_p
     gocode.Disconnect.argtypes = [ctypes.c_char_p]
     gocode.ResolveContactQRLink.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
     gocode.ResolveContactQRLink.restype = ctypes.POINTER(Bytes)
@@ -354,9 +354,9 @@ if not os.environ.get("SPHINX"):
     gocode.PairPhone.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
     gocode.PairPhone.restype = ctypes.POINTER(Bytes)
     gocode.SendAppState.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
-    gocode.SendAppState.restype = ctypes.c_char_p
+    gocode.SendAppState.restype = ctypes.c_void_p
     gocode.SetDefaultDisappearingTimer.argtypes = [ctypes.c_char_p, ctypes.c_int64]
-    gocode.SetDefaultDisappearingTimer.restype = ctypes.c_char_p
+    gocode.SetDefaultDisappearingTimer.restype = ctypes.c_void_p
     gocode.SetDisappearingTimer.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
@@ -364,7 +364,7 @@ if not os.environ.get("SPHINX"):
         ctypes.c_int64,
         ctypes.c_int64,
     ]
-    gocode.SetDisappearingTimer.restype = ctypes.c_char_p
+    gocode.SetDisappearingTimer.restype = ctypes.c_void_p
     gocode.SetForceActiveDeliveryReceipts.argtypes = [ctypes.c_char_p, ctypes.c_bool]
     gocode.SetForceActiveDeliveryReceipts.restype = ctypes.c_void_p
     gocode.SetGroupAnnounce.argtypes = [
@@ -373,14 +373,14 @@ if not os.environ.get("SPHINX"):
         ctypes.c_int,
         ctypes.c_bool,
     ]
-    gocode.SetGroupAnnounce.restype = ctypes.c_char_p
+    gocode.SetGroupAnnounce.restype = ctypes.c_void_p
     gocode.SetGroupLocked.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
         ctypes.c_int,
         ctypes.c_bool,
     ]
-    gocode.SetGroupLocked.restype = ctypes.c_char_p
+    gocode.SetGroupLocked.restype = ctypes.c_void_p
     gocode.SetGroupTopic.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
@@ -389,7 +389,7 @@ if not os.environ.get("SPHINX"):
         ctypes.c_char_p,
         ctypes.c_char_p,
     ]
-    gocode.SetGroupTopic.restype = ctypes.c_char_p
+    gocode.SetGroupTopic.restype = ctypes.c_void_p
     gocode.SetPrivacySetting.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
@@ -397,17 +397,17 @@ if not os.environ.get("SPHINX"):
     ]
     gocode.SetPrivacySetting.restype = ctypes.POINTER(Bytes)
     gocode.SetPassive.argtypes = [ctypes.c_char_p, ctypes.c_bool]
-    gocode.SetPassive.restype = ctypes.c_char_p
+    gocode.SetPassive.restype = ctypes.c_void_p
     gocode.SetStatusMessage.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
-    gocode.SetStatusMessage.restype = ctypes.c_char_p
+    gocode.SetStatusMessage.restype = ctypes.c_void_p
     gocode.SubscribePresence.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
-    gocode.SubscribePresence.restype = ctypes.c_char_p
+    gocode.SubscribePresence.restype = ctypes.c_void_p
     gocode.UnfollowNewsletter.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
         ctypes.c_int,
     ]
-    gocode.UnfollowNewsletter.restype = ctypes.c_char_p
+    gocode.UnfollowNewsletter.restype = ctypes.c_void_p
     gocode.UnlinkGroup.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
@@ -415,7 +415,7 @@ if not os.environ.get("SPHINX"):
         ctypes.c_char_p,
         ctypes.c_int,
     ]
-    gocode.UnlinkGroup.restype = ctypes.c_char_p
+    gocode.UnlinkGroup.restype = ctypes.c_void_p
     gocode.UpdateBlocklist.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
@@ -455,13 +455,13 @@ if not os.environ.get("SPHINX"):
         ctypes.c_char_p,
         ctypes.c_char_p,
     ]
-    gocode.PutContactName.restype = ctypes.c_char_p
+    gocode.PutContactName.restype = ctypes.c_void_p
     gocode.PutAllContactNames.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
         ctypes.c_int,
     ]
-    gocode.PutAllContactNames.restype = ctypes.c_char_p
+    gocode.PutAllContactNames.restype = ctypes.c_void_p
     gocode.GetContact.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
     gocode.GetContact.restype = ctypes.POINTER(Bytes)
     gocode.GetAllContacts.argtypes = [ctypes.c_char_p]
@@ -472,25 +472,25 @@ if not os.environ.get("SPHINX"):
         ctypes.c_int,
         ctypes.c_float,
     ]
-    gocode.PutMutedUntil.restype = ctypes.c_char_p
+    gocode.PutMutedUntil.restype = ctypes.c_void_p
     gocode.PutPinned.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
         ctypes.c_int,
         ctypes.c_bool,
     ]
-    gocode.PutPinned.restype = ctypes.c_char_p
+    gocode.PutPinned.restype = ctypes.c_void_p
     gocode.PutArchived.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
         ctypes.c_int,
         ctypes.c_bool,
     ]
-    gocode.PutArchived.restype = ctypes.c_char_p
+    gocode.PutArchived.restype = ctypes.c_void_p
     gocode.GetChatSettings.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
     gocode.GetChatSettings.restype = ctypes.POINTER(Bytes)
     gocode.GetAllDevices.argtypes = [ctypes.c_char_p, func_callback_bytes2]
-    gocode.GetAllDevices.restype = ctypes.c_char_p
+    gocode.GetAllDevices.restype = ctypes.c_void_p
     gocode.SendFBMessage.argtypes = [
         ctypes.c_char_p,
         ctypes.c_char_p,
@@ -504,7 +504,7 @@ if not os.environ.get("SPHINX"):
     ]
     gocode.SendFBMessage.restype = ctypes.POINTER(Bytes)
     gocode.SendPresence.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
-    gocode.SendPresence.restype = ctypes.c_char_p
+    gocode.SendPresence.restype = ctypes.c_void_p
     gocode.DecryptPollVote.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
     gocode.DecryptPollVote.restype = ctypes.POINTER(Bytes)
     gocode.Stop.argtypes = [ctypes.c_char_p]
@@ -514,7 +514,68 @@ if not os.environ.get("SPHINX"):
     gocode.FreeBytesStruct.argtypes = [ctypes.POINTER(Bytes)]
     gocode.FreeBytesStruct.restype = None
     gocode.SetPushName.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
-    gocode.SetPushName.restype = ctypes.c_char_p
+    gocode.SetPushName.restype = ctypes.c_void_p
+
+    gocode.FreeString.argtypes = [ctypes.c_void_p]
+    gocode.FreeString.restype = None
+
+    def consume_cstring(result, func, arguments):
+        """ctypes errcheck for FFI functions returning a Go-allocated ``*C.char``.
+
+        Copies the string into ``bytes`` -- exactly what a ``c_char_p`` restype
+        used to yield, so callers are unaffected -- then frees the C allocation
+        via ``FreeString``. Without this the Go ``C.CString`` is leaked on every
+        call: a ``c_char_p`` restype copies the bytes and discards the pointer,
+        leaving the allocation unreachable.
+        """
+        if not result:
+            return b""
+        try:
+            return ctypes.string_at(result)
+        finally:
+            gocode.FreeString(result)
+
+    # FFI functions that return a Go-allocated C string. Each is declared
+    # ``restype = ctypes.c_void_p`` above so the raw pointer survives the call;
+    # ``consume_cstring`` then reads and frees it. Keep this list in sync with
+    # those declarations. (GetVersion is intentionally excluded: it is called
+    # once during bootstrap, so its one-off leak is negligible and freeing it
+    # is kept out of the binary-loading path.)
+    for _string_returning_func in (
+        "Neonize",
+        "LeaveGroup",
+        "SetGroupName",
+        "SendChatPresence",
+        "GenerateMessageID",
+        "FollowNewsletter",
+        "JoinGroupWithInvite",
+        "LinkGroup",
+        "Logout",
+        "MarkRead",
+        "NewsletterMarkViewed",
+        "NewsletterSendReaction",
+        "NewsletterToggleMute",
+        "SendAppState",
+        "SetDefaultDisappearingTimer",
+        "SetDisappearingTimer",
+        "SetGroupAnnounce",
+        "SetGroupLocked",
+        "SetGroupTopic",
+        "SetPassive",
+        "SetStatusMessage",
+        "SubscribePresence",
+        "UnfollowNewsletter",
+        "UnlinkGroup",
+        "PutContactName",
+        "PutAllContactNames",
+        "PutMutedUntil",
+        "PutPinned",
+        "PutArchived",
+        "GetAllDevices",
+        "SendPresence",
+        "SetPushName",
+    ):
+        getattr(gocode, _string_returning_func).errcheck = consume_cstring
 else:
     gocode: Any = object()
 


### PR DESCRIPTION
# fix: free C strings leaked across the Go/Python FFI boundary

## Summary

Many of neonize's FFI functions return a status/result string. On the Go side
that string is a `*C.char` allocated by `C.CString`; on the Python side the
function is declared `restype = ctypes.c_char_p`. ctypes copies the bytes into a
Python `bytes` object and **discards the pointer**, and there is no `free`-style
export to release the C allocation — so **every such call leaks the
Go-allocated string**.

Each leak is small (often an empty success marker), but it is unbounded over the
lifetime of a long-running client: `mark_read`, `send_chat_presence`,
`send_presence`, the `Newsletter*` calls, the `SetGroup*` calls and others all
hit it, and an event-driven bot calls them continuously.

(The April 2026 FFI refactor fixed the `StopAll` CString leak specifically; this
PR addresses the same class systematically for the remaining ~32
string-returning functions.)

## Root cause

With `restype = c_char_p`, ctypes builds a Python `bytes` from the returned
`*C.char` and the original pointer is no longer reachable, so it can never be
freed. Freeing requires keeping the raw pointer — i.e. `restype = c_void_p`.

## Fix

**Go (`goneonize/main.go`)** — add a `FreeString` export, mirroring the existing
`FreeBytesStruct`:

```go
//export FreeString
func FreeString(str *C.char) {
	if str != nil {
		C.free(unsafe.Pointer(str))
	}
}
```

**Python (`neonize/_binder.py`)** — declare the 32 affected functions
`restype = ctypes.c_void_p` so the raw pointer survives the call, and attach a
ctypes `errcheck` hook that copies the string and then frees it:

```python
def consume_cstring(result, func, arguments):
    if not result:
        return b""
    try:
        return ctypes.string_at(result)
    finally:
        gocode.FreeString(result)
```

The hook returns `bytes` — exactly what `c_char_p` produced — so **no caller
changes are required**.

## Backward compatibility

Fully backward compatible. Callers previously received `bytes` (or `None` for a
NULL pointer); they now receive `bytes` (or `b""` for NULL). No public API
change.

## Scope / notes

- 32 functions covered. `GetVersion` is intentionally kept `c_char_p`: it runs
  once during bootstrap, so its one-off leak is negligible and freeing it is
  kept out of the delicate binary-loading path.
- `LinkGroup` was additionally mis-declared `restype = POINTER(Bytes)` even
  though it returns a `*C.char` (`return C.CString(...)`). That type mismatch
  made `link_group()` raise `AttributeError` on the `.decode()` call instead of
  ever surfacing `LinkGroupError`. Switching it to `c_void_p` like the rest
  fixes both the leak and that broken call path.
- Assumes every `*C.char` returned to Python is `C.CString`-allocated (holds
  across `main.go` and `helpers.go`'s `stringError`). `C.free` is the correct
  deallocator for `C.CString`, consistent with `FreeBytesStruct`.
- The prebuilt `.so` / `.dll` must be rebuilt so the new `FreeString` export is
  present (release pipeline).

## Testing

Built and verified on Linux (x86_64, Go 1.25):

- `python -m tools.goneonize goneonize` — compiles cleanly; `nm -D` on the
  resulting `.so` shows the new `FreeString` export alongside `FreeBytesStruct`.
- `python examples/basic.py` — the modified `_binder.py` imports, the client
  connects and reaches the pairing QR, i.e. the FFI layer, the retargeted
  restypes and the `errcheck` loop all load cleanly.
- The `c_void_p` + `errcheck` + `free` approach was additionally exercised live
  in a downstream bot: a session handling a multi-turn conversation kept running
  with flat RSS and no crash.
