### PR TITLE
fix: skip events with no registered handler instead of raising KeyError

### DIFF
--- a/neonize/aioze/events.py
+++ b/neonize/aioze/events.py
@@ -142,14 +142,11 @@ class Event:
             return
         elif code == 3:
             self.client.connected = True
-        # loop = asyncio.new_event_loop()
-        # loop.run_until_complete(
-        #     self.list_func[code](self.client, message)
-        # )
-        # loop.close()
-        asyncio.run_coroutine_threadsafe(
-            self.list_func[code](self.client, message), event_global_loop
-        )
+        handler = self.list_func.get(code)
+        if handler is not None:
+            asyncio.run_coroutine_threadsafe(
+                handler(self.client, message), event_global_loop
+            )
 
     async def __onqr(self, _: NewAClient, data_qr: bytes):
         """

--- a/neonize/events.py
+++ b/neonize/events.py
@@ -159,7 +159,9 @@ class Event:
             return
         elif code == 3:
             self.client.connected = True
-        self.list_func[code](self.client, message)
+        handler = self.list_func.get(code)
+        if handler is not None:
+            handler(self.client, message)
 
     def __onqr(self, _: NewClient, data_qr: bytes):
         """


### PR DESCRIPTION
## Problem

`Event.execute()` — in both the sync `events.py` and the async
`aioze/events.py` — dispatches an incoming event with
`self.list_func[code](...)`, a direct dict index. If no handler has been
registered for that event type, this raises `KeyError`.

WhatsApp emits many event types: receipts, presence, chat presence, group
info, picture updates, offline-sync markers, and more. A client that
registers only, say, `@event(MessageEv)` therefore hits a `KeyError` on
**every other event**. `execute()` runs inside the ctypes callback invoked
from Go, where a Python exception is swallowed — so the event is silently
dropped with no clear error.

## Fix

Look the handler up with `.get(code)` and skip dispatch when none is
registered, in both `execute()` implementations. Unregistered events are
now simply ignored, which is the expected behaviour.

No API change — a registered handler behaves exactly as before.
