### PR TITLE
fix: add a timeout to the goneonize binary download

### DIFF
--- a/neonize/download.py
+++ b/neonize/download.py
@@ -10,7 +10,7 @@ class UnsupportedPlatform(Exception):
     pass
 
 def __download(url: str, fname: str, chunk_size=1024):
-    resp = requests.get(url, stream=True)
+    resp = requests.get(url, stream=True, timeout=30)
     if resp.status_code != 200:
         resp.close()
         raise UnsupportedPlatform(generated_name())


### PR DESCRIPTION
## Problem

`__download()` in `download.py` calls `requests.get(url, stream=True)` with
no `timeout`. If the connection stalls while fetching the shared library,
the request blocks forever.

The download runs at import time on first use (when the `.so` / `.dll` is
missing), so a stalled download hangs `import neonize` itself — with no way
to recover short of killing the process.

## Fix

Pass `timeout=30` to `requests.get()`. A genuinely stalled connection now
fails with a `requests` timeout instead of hanging indefinitely.
