### PR TITLE
fix: cap load_goneonize retries instead of looping forever

### DIFF
--- a/neonize/_binder.py
+++ b/neonize/_binder.py
@@ -19,7 +19,8 @@ func_callback_bytes2 = ctypes.CFUNCTYPE(None, ctypes.c_void_p, ctypes.c_int)  # 
 
 
 def load_goneonize():
-    while True:
+    last_error: Exception | None = None
+    for _ in range(3):
         try:
             gocode = ctypes.CDLL(f"{root_dir}/{generated_name()}")
             gocode.GetVersion.restype = ctypes.c_char_p
@@ -29,8 +30,12 @@ def load_goneonize():
         except OSError as e:
             print("e", e)
             raise e
-        except Exception:
+        except Exception as e:
+            last_error = e
             download()
+    raise RuntimeError(
+        f"failed to load goneonize after 3 attempts; last error: {last_error}"
+    )
 
 
 class Bytes(ctypes.Structure):


### PR DESCRIPTION
## Problem

`load_goneonize()` retries in a `while True` loop, calling `download()` on
every failure. If the downloaded binary never satisfies the version check —
e.g. a packaging mismatch between the published `.so` and
`__GONEONIZE_VERSION__` — the loop never terminates: it re-downloads the
same binary on every iteration, spinning forever and hammering the release
URL.

## Fix

Cap the loop at 3 attempts. After the last failed attempt, raise a clear
`RuntimeError` carrying the last error instead of looping. `OSError` keeps
its existing behaviour (re-raised immediately, no retry).
