### PR TITLE
fix: stop the Go side when the async connect task is cancelled

### DIFF
--- a/goneonize/main.go
+++ b/goneonize/main.go
@@ -524,10 +524,14 @@ func Stop(id *C.char) {
 		cancelFunc()
 		delete(StopSignal, C.GoString(id))
 	}
-	if eventChan, exists := eventChannel[C.GoString(id)]; exists {
-		close(eventChan)
-		delete(eventChannel, C.GoString(id))
-	}
+	// Drop the event channel reference without closing it. Closing it raced
+	// with CallbackFunction's select loop: once the channel is closed, its
+	// `case message := <-channel` branch fires immediately with a nil
+	// *MessageEvent, which then nil-dereferences in proto.Marshal and panics
+	// the process. CallbackFunction already returns cleanly via <-ctx.Done()
+	// (cancelled just above); once it does, the channel is unreferenced and
+	// garbage-collected.
+	delete(eventChannel, C.GoString(id))
 }
 
 //export Neonize

--- a/neonize/aioze/client.py
+++ b/neonize/aioze/client.py
@@ -3286,23 +3286,35 @@ class NewAClient:
 
         # Initiate connection to the server
         async def _connect_and_check():
-            err = await self.__client.Neonize(
-                self.name.encode(),
-                self.uuid,
-                jidbuf,
-                jidbuf_size,
-                LogLevel.from_logging(log.level).level,
-                func_string(self.__onQr),
-                func_string(self.__onLoginStatus),
-                func_callback_bytes(self.event.execute),
-                func_callback_bytes2(log_whatsmeow),
-                (ctypes.c_char * len(self.event.list_func)).from_buffer(d),
-                len(d),
-                deviceprops,
-                len(deviceprops),
-                b"",
-                0,
-            )
+            try:
+                err = await self.__client.Neonize(
+                    self.name.encode(),
+                    self.uuid,
+                    jidbuf,
+                    jidbuf_size,
+                    LogLevel.from_logging(log.level).level,
+                    func_string(self.__onQr),
+                    func_string(self.__onLoginStatus),
+                    func_callback_bytes(self.event.execute),
+                    func_callback_bytes2(log_whatsmeow),
+                    (ctypes.c_char * len(self.event.list_func)).from_buffer(d),
+                    len(d),
+                    deviceprops,
+                    len(deviceprops),
+                    b"",
+                    0,
+                )
+            except asyncio.CancelledError:
+                # Neonize() is a blocking Go call dispatched to a non-daemon
+                # ThreadPoolExecutor thread via asyncio.to_thread; it only
+                # returns once the Go-side context is cancelled. Cancelling
+                # this task -- which is what asyncio.run() does on a
+                # KeyboardInterrupt -- unblocks this coroutine but cannot stop
+                # the worker thread. Without signalling Go, that thread runs
+                # forever and interpreter shutdown hangs joining it. Tell Go to
+                # stop so Neonize() returns and the worker thread can exit.
+                gocode.Stop(self.uuid)
+                raise
             if err:
                 raise NeonizeError(err.decode())
 


### PR DESCRIPTION
## Problem

The async client (`aioze`) does not shut down cleanly: after `Ctrl-C` the
interpreter hangs at exit, and a second `Ctrl-C` is needed to actually quit.

`NewAClient.connect()` dispatches the blocking Go `Neonize()` call to a worker
thread via `asyncio.to_thread` — i.e. `loop.run_in_executor(None, ...)`, the
default `ThreadPoolExecutor`, whose worker threads are **non-daemon**. On the Go
side, `Neonize()` ends in `CallbackFunction()`, an infinite `select` loop that
only returns once its `context.Context` is cancelled — which happens solely
through the `Stop` / `StopAll` exports.

On `Ctrl-C`, `asyncio.run()` cancels the connect task. That raises
`CancelledError` in the coroutine, but **`run_in_executor` cannot cancel an
already-running thread** — the worker thread keeps blocking inside `Neonize()`.
Nothing signals the Go side, so `Neonize()` never returns and the thread never
exits. Interpreter shutdown then runs `concurrent.futures`' thread-pool `atexit`
handler, which `join()`s every worker thread — and hangs forever on the
`Neonize()` thread.

This is the underlying cause behind a long line of "can't stop / disconnect
cleanly" reports: #27, #41, #170, #173, #19.

## Fix

**Python (`neonize/aioze/client.py`)** — make the connect task signal the Go
side when it is cancelled. `_connect_and_check()` now catches
`asyncio.CancelledError` around the `Neonize()` await and calls `Stop` before
re-raising, so the Go context is cancelled, `Neonize()` returns, and the worker
thread exits cleanly:

```python
except asyncio.CancelledError:
    gocode.Stop(self.uuid)
    raise
```

**Go (`goneonize/main.go`)** — fix a race in `Stop()` that this change now
routes into on every shutdown. `Stop()` cancelled the context **and then**
`close()`d the event channel. Once the channel is closed, `CallbackFunction`'s
`select` can take the `case message := <-channel` branch with a nil
`*MessageEvent`, which then nil-dereferences in `proto.Marshal` and panics the
process. The `close()` is unnecessary: `CallbackFunction` already returns
cleanly via `<-ctx.Done()` (cancelled just above), after which the channel is
unreferenced and garbage-collected. `Stop()` now just drops the map reference:

```go
delete(eventChannel, C.GoString(id))
```

## Behaviour

- `Ctrl-C` now shuts the async client down on the **first** press; the worker
  thread exits and the interpreter terminates normally.
- An explicit `await client.stop()` / `ClientFactory.stop()` is unaffected —
  same path, now without the channel-close panic risk.
- No public API change.

## Scope / notes

- Removing `close(eventChan)` also removes a second latent panic: an
  `eventChan <- ...` send racing the close would be a "send on closed channel"
  panic. Dropping the reference avoids both directions of the race.
- The prebuilt `.so` / `.dll` must be rebuilt so the `Stop()` change is present
  (release pipeline).

## Testing

Built and verified on Linux (x86_64, Go 1.26):

- `python -m tools.goneonize goneonize` — compiles cleanly.
- The `aioze` connect path imports and the rebuilt `.so` loads.
- Exercised live in a downstream async bot: with the fix, a connected session
  shuts down on a single `Ctrl-C` and the process exits normally; without it,
  the same session hangs at exit and requires a second `Ctrl-C`.
