### PR TITLE
fix: preserve NUL bytes in Go buffers

### DIFF
--- a/neonize/_binder.py
+++ b/neonize/_binder.py
@@ -40,7 +40,10 @@ def load_goneonize():
 
 
 class Bytes(ctypes.Structure):
-    _fields_ = [("ptr", ctypes.c_char_p), ("size", ctypes.c_size_t)]
+    # Go returns raw binary buffers that may contain NUL bytes. Do not use
+    # c_char_p here because ctypes treats it as a NUL-terminated C string and
+    # can truncate/corrupt media bytes such as JPEG/PNG downloads.
+    _fields_ = [("ptr", ctypes.c_void_p), ("size", ctypes.c_size_t)]
 
     def get_bytes(self):
         return ctypes.string_at(self.ptr, self.size)

--- a/tests/test_binder.py
+++ b/tests/test_binder.py
@@ -1,0 +1,14 @@
+import ctypes
+import os
+
+os.environ["SPHINX"] = "1"
+
+from neonize._binder import Bytes
+
+
+def test_bytes_get_bytes_preserves_nul_bytes():
+    payload = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00binary\x00tail"
+    buffer = ctypes.create_string_buffer(payload)
+    data = Bytes(ctypes.cast(buffer, ctypes.c_void_p), len(payload))
+
+    assert data.get_bytes() == payload


### PR DESCRIPTION
## Summary
- store Go-returned byte buffers as raw pointers instead of c_char_p
- preserve embedded NUL bytes in binary media downloads
- add a regression test for Bytes.get_bytes with JPEG-like bytes containing NULs

## Problem
ctypes.c_char_p treats returned pointers as NUL-terminated C strings. Media downloads such as JPEG/PNG can contain NUL bytes near the beginning, causing downloaded bytes to be truncated/corrupted.

## Testing
- python import-based execution of tests/test_binder.py::test_bytes_get_bytes_preserves_nul_bytes
- python -m py_compile neonize/_binder.py tests/test_binder.py