### PR TITLE
feat: add new_device flag to pair additional accounts into one store

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,11 @@ client_factory = ClientFactory("multisession.db")
 for device in client_factory.get_all_devices():
     client_factory.new_client(device.JID)
 
+# Pair an ADDITIONAL account into the same database (shows a fresh QR).
+# Without new_device=True a jid-less client resumes the FIRST stored
+# session instead of pairing a new one.
+new_account = client_factory.new_client(uuid="my-second-account", new_device=True)
+
 # Register shared event handlers
 @client_factory.event(ConnectedEv)
 async def on_connected(client: NewAClient, event: ConnectedEv):

--- a/goneonize/main.go
+++ b/goneonize/main.go
@@ -590,7 +590,7 @@ func Stop(id *C.char) {
 }
 
 //export Neonize
-func Neonize(db *C.char, id *C.char, JIDByte *C.uchar, JIDSize C.int, logLevel *C.char, qrCb C.ptr_to_python_function_string, logStatus C.ptr_to_python_function_string, event C.ptr_to_python_function_bytes, logCb C.ptr_to_python_function_callback_bytes2, subscribes *C.uchar, lenSubscriber C.int, devicePropsBuf *C.uchar, devicePropsSize C.int, pairphone *C.uchar, pairphoneSize C.int, proxySettingsRaw *C.struct_ProxySettings) *C.char {
+func Neonize(db *C.char, id *C.char, JIDByte *C.uchar, JIDSize C.int, newDevice C.int, logLevel *C.char, qrCb C.ptr_to_python_function_string, logStatus C.ptr_to_python_function_string, event C.ptr_to_python_function_bytes, logCb C.ptr_to_python_function_callback_bytes2, subscribes *C.uchar, lenSubscriber C.int, devicePropsBuf *C.uchar, devicePropsSize C.int, pairphone *C.uchar, pairphoneSize C.int, proxySettingsRaw *C.struct_ProxySettings) *C.char {
 	subscribers := map[int]bool{}
 	var deviceProps waCompanionReg.DeviceProps
 	loginStateChan := make(chan bool)
@@ -613,6 +613,9 @@ func Neonize(db *C.char, id *C.char, JIDByte *C.uchar, JIDSize C.int, logLevel *
 		return C.CString(err.Error())
 	}
 	// If you want multiple sessions, remember their JIDs and use .GetDevice(jid) or .GetAllDevices() instead.
+	// Pass newDevice != 0 to pair an ADDITIONAL account: it forces a brand-new
+	// blank device (fresh QR) even when the store already holds other sessions,
+	// where GetFirstDevice would silently resume the first stored one.
 	var deviceStore *store.Device
 	var err_device error
 	var JID defproto.JID
@@ -622,6 +625,8 @@ func Neonize(db *C.char, id *C.char, JIDByte *C.uchar, JIDSize C.int, logLevel *
 			return C.CString(jidbyte_err.Error())
 		}
 		deviceStore, err_device = container.GetDevice(context.TODO(), utils.DecodeJidProto(&JID))
+	} else if int(newDevice) != 0 {
+		deviceStore = container.NewDevice()
 	} else {
 		deviceStore, err_device = container.GetFirstDevice(context.TODO())
 	}

--- a/neonize/_binder.py
+++ b/neonize/_binder.py
@@ -115,6 +115,7 @@ if not os.environ.get("SPHINX"):
         ctypes.c_char_p,
         ctypes.c_char_p,
         ctypes.c_int,
+        ctypes.c_int,
         ctypes.c_char_p,
         func_string,
         func_string,

--- a/neonize/aioze/client.py
+++ b/neonize/aioze/client.py
@@ -425,6 +425,7 @@ class NewAClient:
         jid: Optional[JID] = None,
         props: Optional[DeviceProps] = None,
         uuid: Optional[str] = None,
+        new_device: bool = False,
     ):
         """Initializes a new client instance.
 
@@ -437,9 +438,14 @@ class NewAClient:
         :type messageCallback: Optional[Callable[[NewClient, MessageSource, Message], None]], optional
         :param uuid: Optional. A unique identifier for the client, defaults to None.
         :type uuid: Optional[str], optional
+        :param new_device: Optional. Pair a brand-new account (fresh QR) even if the
+            database already stores other sessions; without it, connecting without a
+            jid resumes the FIRST stored session. Requires uuid. Defaults to False.
+        :type new_device: bool, optional
         """
         self.name = name
         self.device_props = props
+        self.new_device = new_device
         self.jid = jid
         self.uuid = (
             jid.User if jid else (uuid or name)
@@ -3385,6 +3391,7 @@ class NewAClient:
                     self.uuid,
                     jidbuf,
                     jidbuf_size,
+                    int(self.new_device),
                     LogLevel.from_logging(log.level).level,
                     func_string(self.__onQr),
                     func_string(self.__onLoginStatus),
@@ -3477,6 +3484,7 @@ class ClientFactory:
         jid: Optional[JID] = None,
         uuid: Optional[str] = None,
         props: Optional[DeviceProps] = None,
+        new_device: bool = False,
     ) -> NewAClient:
         """
         This function creates a new instance of the client. If the jid parameter is not provided, a new client will be created.
@@ -3495,7 +3503,7 @@ class ClientFactory:
             # unique
             raise Exception("JID and UUID cannot be none")
 
-        client = NewAClient(self.database_name, jid, props, uuid)
+        client = NewAClient(self.database_name, jid, props, uuid, new_device)
         client.event.list_func = self.event.list_func
         self.clients.append(client)
         return client

--- a/neonize/client.py
+++ b/neonize/client.py
@@ -387,6 +387,7 @@ class NewClient:
         jid: Optional[JID] = None,
         props: Optional[DeviceProps] = None,
         uuid: Optional[str] = None,
+        new_device: bool = False,
     ):
         """Initializes a new client instance.
 
@@ -399,9 +400,14 @@ class NewClient:
         :type messageCallback: Optional[Callable[[NewClient, MessageSource, Message], None]], optional
         :param uuid: Optional. A unique identifier for the client, defaults to None.
         :type uuid: Optional[str], optional
+        :param new_device: Optional. Pair a brand-new account (fresh QR) even if the
+            database already stores other sessions; without it, connecting without a
+            jid resumes the FIRST stored session. Requires uuid. Defaults to False.
+        :type new_device: bool, optional
         """
         self.name = name
         self.device_props = props
+        self.new_device = new_device
         self.jid = jid
         self.uuid = (jid.User if jid else (uuid or name)).encode()
         self.__client = gocode
@@ -3349,6 +3355,7 @@ class NewClient:
                     self.uuid,
                     jidbuf,
                     jidbuf_size,
+                    int(self.new_device),
                     LogLevel.from_logging(log.level).level,
                     qr_cb,
                     login_cb,
@@ -3451,6 +3458,7 @@ class ClientFactory:
         jid: Optional[JID] = None,
         uuid: Optional[str] = None,
         props: Optional[DeviceProps] = None,
+        new_device: bool = False,
     ) -> NewClient:
         """
         This function creates a new instance of the client. If the jid parameter is not provided, a new client will be created.
@@ -3469,7 +3477,7 @@ class ClientFactory:
             # unique
             raise Exception("JID and UUID cannot be none")
 
-        client = NewClient(self.database_name, jid, props, uuid)
+        client = NewClient(self.database_name, jid, props, uuid, new_device)
         client.event.list_func = self.event.list_func
         self.clients.append(client)
         return client


### PR DESCRIPTION
## Problem

In a database that already contains a session, it is currently impossible to pair a **second** account. A jid-less client resolves its device via `container.GetFirstDevice()`, which only creates a blank device when the store is **empty** — so `ClientFactory.new_client(uuid=...)` on a populated store silently resumes the first stored session instead: no QR is ever emitted, and the resumed session kicks the original client with a replaced-stream error. `container.NewDevice()` — whatsmeow's API for exactly this — is not exposed anywhere in goneonize.

This is the failure described in #104 ("a new client was created, but there is no display to scan the QR code"). The README's multi-session example only covers *resuming* known JIDs, matching the comment in `main.go`: *"If you want multiple sessions, remember their JIDs and use .GetDevice(jid)"* — onboarding session #2 has no supported path today. Downstream apps currently have to work around this with one database per account.

## Change

- `goneonize/main.go`: new `newDevice C.int` parameter on the `Neonize` export; when set (and no jid is given) the client is built on `container.NewDevice()` instead of `GetFirstDevice()`, so a fresh QR pairing starts alongside existing sessions.
- `neonize/client.py`, `neonize/aioze/client.py`: `new_device: bool = False` on `NewClient`/`NewAClient` and both `ClientFactory.new_client()`; flag passed through to Go.
- `neonize/_binder.py`: matching `ctypes.c_int` in the `Neonize` argtypes.
- `README.md`: multi-session example gains an "add another account" line.

Usage:
```python
new_account = client_factory.new_client(uuid="my-second-account", new_device=True)
```

## Compatibility

Default behavior is byte-for-byte unchanged: jid → `GetDevice`, no jid → `GetFirstDevice`. The C signature change is internal — the Python layer and the goneonize binary ship together per release. The blank device from `NewDevice()` is persisted by whatsmeow on successful pairing, exactly like the empty-store first pairing today.

## Testing

- `go build ./...` passes on the patched `goneonize`.
- `python -m py_compile` on the three touched Python files.
- Marked **draft** because I have not yet run a live two-account QR pairing against this build — will do so and report back, but happy for CI/maintainer eyes meanwhile.

Fixes #104