### PR TITLE
feat: make bot node injection configurable via NEONIZE_BOT_TAG

### DIFF
--- a/goneonize/main.go
+++ b/goneonize/main.go
@@ -16,6 +16,7 @@ import (
 	// "crypto/sha256"
 	// "encoding/hex"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 	"unsafe"
@@ -141,6 +142,26 @@ func getButtonTypeFromMessage(msg *waE2E.Message) string {
 	}
 }
 
+// shouldAddBotNode reports whether the <bot biz_bot="1"/> node should be
+// appended for the given chat. Controlled by the NEONIZE_BOT_SCOPE env var:
+//
+//	"private" (default) - bot node only in 1:1 chats (upstream behavior)
+//	"group"             - bot node only in group chats
+//	"both"              - bot node in 1:1 and group chats
+//	"off"               - never append the bot node
+func shouldAddBotNode(isPrivate bool) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("NEONIZE_BOT_SCOPE"))) {
+	case "group":
+		return !isPrivate
+	case "both", "all":
+		return true
+	case "off", "none", "false", "0":
+		return false
+	default:
+		return isPrivate
+	}
+}
+
 // GenerateWABinary for create button
 func GenerateWABinary(ctx context.Context, to types.JID, msg *waE2E.Message) *[]waBinary.Node {
 	isPrivate := to.Server == types.DefaultUserServer
@@ -225,7 +246,7 @@ func GenerateWABinary(ctx context.Context, to types.JID, msg *waE2E.Message) *[]
 			}
 		}
 
-		if isPrivate {
+		if shouldAddBotNode(isPrivate) {
 			botNode := waBinary.Node{
 				Tag:   "bot",
 				Attrs: waBinary.Attrs{"biz_bot": "1"},
@@ -265,7 +286,7 @@ func GenerateWABinary(ctx context.Context, to types.JID, msg *waE2E.Message) *[]
 		}
 		nodes = append(nodes, bizNode)
 
-		if isPrivate {
+		if shouldAddBotNode(isPrivate) {
 			botNode := waBinary.Node{
 				Tag:   "bot",
 				Attrs: waBinary.Attrs{"biz_bot": "1"},
@@ -274,7 +295,7 @@ func GenerateWABinary(ctx context.Context, to types.JID, msg *waE2E.Message) *[]
 		}
 
 	default:
-		if isPrivate {
+		if shouldAddBotNode(isPrivate) {
 			botNode := waBinary.Node{
 				Tag:   "bot",
 				Attrs: waBinary.Attrs{"biz_bot": "1"},

--- a/goneonize/main.go
+++ b/goneonize/main.go
@@ -143,18 +143,12 @@ func getButtonTypeFromMessage(msg *waE2E.Message) string {
 }
 
 // shouldAddBotNode reports whether the <bot biz_bot="1"/> node should be
-// appended for the given chat. Controlled by the NEONIZE_BOT_SCOPE env var:
+// appended for the given chat. Controlled by the NEONIZE_BOT_TAG env var:
 //
-//	"private" (default) - bot node only in 1:1 chats (upstream behavior)
-//	"group"             - bot node only in group chats
-//	"both"              - bot node in 1:1 and group chats
-//	"off"               - never append the bot node
+//	"on"  (default) - append the bot node in 1:1 chats (upstream behavior)
+//	"off"           - never append the bot node
 func shouldAddBotNode(isPrivate bool) bool {
-	switch strings.ToLower(strings.TrimSpace(os.Getenv("NEONIZE_BOT_SCOPE"))) {
-	case "group":
-		return !isPrivate
-	case "both", "all":
-		return true
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("NEONIZE_BOT_TAG"))) {
 	case "off", "none", "false", "0":
 		return false
 	default:

--- a/goneonize/version.go
+++ b/goneonize/version.go
@@ -4,6 +4,6 @@ import "C"
 
 //export GetVersion
 func GetVersion() *C.char {
-	version := "0.3.13"
+	version := "0.4.3.post0"
 	return C.CString(version)
 }


### PR DESCRIPTION
## Summary
Makes the `<bot biz_bot="1"/>` node injection in `GenerateWABinary` configurable at runtime through the `NEONIZE_BOT_TAG` environment variable, instead of being hardcoded to always-on for private chats.

## Changes
- `goneonize/main.go`: added `shouldAddBotNode(isPrivate bool)` helper that reads `NEONIZE_BOT_TAG` and replaces the three hardcoded `if isPrivate` bot-node blocks in `GenerateWABinary`.
- `goneonize/version.go`: align `GetVersion()` with the released `0.4.3.post0` (the repo was still on `0.3.13`, which breaks the Python binder's version check when building from source).

## NEONIZE_BOT_TAG values
| Value | Behavior |
|---|---|
| `on` (default) | bot node in 1:1 chats — upstream behavior |
| `off` | never append the bot node |

Defaults to `on` when unset, so this is fully backward compatible.

## Notes
- Tested on Windows (amd64): `on` and `off` both verified live — the AI/bot label shows in 1:1 chats with `on` and is absent with `off`.
- Group sends with the bot node were originally considered, but WhatsApp's server rejects the node in group chats with error 479, so only `on`/`off` are exposed.
- The Go toolchain was installed fresh (go1.26.5 + WinLibs MinGW); build passes with `go build -buildmode=c-shared -ldflags=-s .`
