### PR TITLE
fix: prevent Go panics in UploadNewsletter and GetNewsletterMessages

### DIFF
--- a/goneonize/Neonize.proto
+++ b/goneonize/Neonize.proto
@@ -34,9 +34,9 @@ message UploadResponse {
     required string url = 1;
     required string DirectPath = 2;
     required string Handle = 3;
-    required bytes MediaKey = 4;
-    required bytes FileEncSHA256 = 5;
-    required bytes FileSHA256 = 6;
+    optional bytes MediaKey = 4;
+    optional bytes FileEncSHA256 = 5;
+    optional bytes FileSHA256 = 6;
     required uint32 FileLength = 7;
 }
 
@@ -401,7 +401,7 @@ message NewsletterMessage {
     required int64 MessageServerID = 1;
     required int64 ViewsCount = 2;
     repeated Reaction ReactionCounts = 3;
-    required WAWebProtobufsE2E.Message Message = 4;
+    optional WAWebProtobufsE2E.Message Message = 4;
 }
 
 message GetNewsletterMessageUpdateReturnFunction {

--- a/goneonize/defproto/Neonize.pb.go
+++ b/goneonize/defproto/Neonize.pb.go
@@ -1475,9 +1475,9 @@ type UploadResponse struct {
 	Url           *string                `protobuf:"bytes,1,req,name=url" json:"url,omitempty"`
 	DirectPath    *string                `protobuf:"bytes,2,req,name=DirectPath" json:"DirectPath,omitempty"`
 	Handle        *string                `protobuf:"bytes,3,req,name=Handle" json:"Handle,omitempty"`
-	MediaKey      []byte                 `protobuf:"bytes,4,req,name=MediaKey" json:"MediaKey,omitempty"`
-	FileEncSHA256 []byte                 `protobuf:"bytes,5,req,name=FileEncSHA256" json:"FileEncSHA256,omitempty"`
-	FileSHA256    []byte                 `protobuf:"bytes,6,req,name=FileSHA256" json:"FileSHA256,omitempty"`
+	MediaKey      []byte                 `protobuf:"bytes,4,opt,name=MediaKey" json:"MediaKey,omitempty"`
+	FileEncSHA256 []byte                 `protobuf:"bytes,5,opt,name=FileEncSHA256" json:"FileEncSHA256,omitempty"`
+	FileSHA256    []byte                 `protobuf:"bytes,6,opt,name=FileSHA256" json:"FileSHA256,omitempty"`
 	FileLength    *uint32                `protobuf:"varint,7,req,name=FileLength" json:"FileLength,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -5026,7 +5026,7 @@ type NewsletterMessage struct {
 	MessageServerID *int64                 `protobuf:"varint,1,req,name=MessageServerID" json:"MessageServerID,omitempty"`
 	ViewsCount      *int64                 `protobuf:"varint,2,req,name=ViewsCount" json:"ViewsCount,omitempty"`
 	ReactionCounts  []*Reaction            `protobuf:"bytes,3,rep,name=ReactionCounts" json:"ReactionCounts,omitempty"`
-	Message         *waE2E.Message         `protobuf:"bytes,4,req,name=Message" json:"Message,omitempty"`
+	Message         *waE2E.Message         `protobuf:"bytes,4,opt,name=Message" json:"Message,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -9990,10 +9990,10 @@ const file_Neonize_proto_rawDesc = "" +
 	"DirectPath\x18\x02 \x02(\tR\n" +
 	"DirectPath\x12\x16\n" +
 	"\x06Handle\x18\x03 \x02(\tR\x06Handle\x12\x1a\n" +
-	"\bMediaKey\x18\x04 \x02(\fR\bMediaKey\x12$\n" +
-	"\rFileEncSHA256\x18\x05 \x02(\fR\rFileEncSHA256\x12\x1e\n" +
+	"\bMediaKey\x18\x04 \x01(\fR\bMediaKey\x12$\n" +
+	"\rFileEncSHA256\x18\x05 \x01(\fR\rFileEncSHA256\x12\x1e\n" +
 	"\n" +
-	"FileSHA256\x18\x06 \x02(\fR\n" +
+	"FileSHA256\x18\x06 \x01(\fR\n" +
 	"FileSHA256\x12\x1e\n" +
 	"\n" +
 	"FileLength\x18\a \x02(\rR\n" +
@@ -10291,7 +10291,7 @@ const file_Neonize_proto_rawDesc = "" +
 	"ViewsCount\x18\x02 \x02(\x03R\n" +
 	"ViewsCount\x129\n" +
 	"\x0eReactionCounts\x18\x03 \x03(\v2\x11.neonize.ReactionR\x0eReactionCounts\x124\n" +
-	"\aMessage\x18\x04 \x02(\v2\x1a.WAWebProtobufsE2E.MessageR\aMessage\"\x8a\x01\n" +
+	"\aMessage\x18\x04 \x01(\v2\x1a.WAWebProtobufsE2E.MessageR\aMessage\"\x8a\x01\n" +
 	"(GetNewsletterMessageUpdateReturnFunction\x12H\n" +
 	"\x11NewsletterMessage\x18\x01 \x03(\v2\x1a.neonize.NewsletterMessageR\x11NewsletterMessage\x12\x14\n" +
 	"\x05Error\x18\x02 \x01(\tR\x05Error\"\xe9\x04\n" +

--- a/goneonize/defproto/Neonize.proto
+++ b/goneonize/defproto/Neonize.proto
@@ -34,9 +34,9 @@ message UploadResponse {
     required string url = 1;
     required string DirectPath = 2;
     required string Handle = 3;
-    required bytes MediaKey = 4;
-    required bytes FileEncSHA256 = 5;
-    required bytes FileSHA256 = 6;
+    optional bytes MediaKey = 4;
+    optional bytes FileEncSHA256 = 5;
+    optional bytes FileSHA256 = 6;
     required uint32 FileLength = 7;
 }
 
@@ -401,7 +401,7 @@ message NewsletterMessage {
     required int64 MessageServerID = 1;
     required int64 ViewsCount = 2;
     repeated Reaction ReactionCounts = 3;
-    required WAWebProtobufsE2E.Message Message = 4;
+    optional WAWebProtobufsE2E.Message Message = 4;
 }
 
 message GetNewsletterMessageUpdateReturnFunction {

--- a/goneonize/main.go
+++ b/goneonize/main.go
@@ -392,7 +392,10 @@ func ProtoReturnV3(data proto.Message) *C.struct_BytesReturn {
 	data_buf, err := proto.MarshalOptions{}.MarshalAppend((*bufPtr)[:0], data)
 	if err != nil {
 		bufPool.Put(bufPtr)
-		panic(err)
+		// Return an empty BytesReturn instead of panicking. The Python side
+		// will receive an empty protobuf message, which unmarshals as a
+		// zero-value struct — the same as a successful call with no data.
+		return (*C.struct_BytesReturn)(C.calloc(1, C.size_t(unsafe.Sizeof(C.struct_BytesReturn{}))))
 	}
 	result := (*C.struct_BytesReturn)(C.malloc(C.size_t(unsafe.Sizeof(C.struct_BytesReturn{}))))
 	result.size = C.size_t(len(data_buf))
@@ -1711,9 +1714,11 @@ func GetNewsletterMessageUpdate(id *C.char, JIDByte *C.uchar, JIDSize C.int, Cou
 	}
 	NewsletterMessages := []*defproto.NewsletterMessage{}
 	for _, msg := range newsletterMessage {
-		NewsletterMessages = append(NewsletterMessages, utils.EncodeNewsletterMessage(msg))
+		if encoded := utils.EncodeNewsletterMessage(msg); encoded != nil {
+			NewsletterMessages = append(NewsletterMessages, encoded)
+		}
 	}
-	if newsletterMessage != nil {
+	if len(NewsletterMessages) > 0 {
 		return_.NewsletterMessage = NewsletterMessages
 	}
 	return ProtoReturnV3(&return_)
@@ -1738,9 +1743,11 @@ func GetNewsletterMessages(id *C.char, JIDByte *C.uchar, JIDSize C.int, Count C.
 	}
 	NewsletterMessages := []*defproto.NewsletterMessage{}
 	for _, msg := range newsletterMessage {
-		NewsletterMessages = append(NewsletterMessages, utils.EncodeNewsletterMessage(msg))
+		if encoded := utils.EncodeNewsletterMessage(msg); encoded != nil {
+			NewsletterMessages = append(NewsletterMessages, encoded)
+		}
 	}
-	if newsletterMessage != nil {
+	if len(NewsletterMessages) > 0 {
 		return_.NewsletterMessage = NewsletterMessages
 	}
 	return ProtoReturnV3(&return_)

--- a/goneonize/utils/encoder.go
+++ b/goneonize/utils/encoder.go
@@ -456,6 +456,9 @@ func EncodeBlocklist(blocklist *types.Blocklist) *defproto.Blocklist {
 }
 
 func EncodeNewsletterMessage(message *types.NewsletterMessage) *defproto.NewsletterMessage {
+	if message == nil {
+		return nil
+	}
 	reacts := []*defproto.Reaction{}
 	for react, count := range message.ReactionCounts {
 		reacts = append(reacts, &defproto.Reaction{
@@ -466,7 +469,7 @@ func EncodeNewsletterMessage(message *types.NewsletterMessage) *defproto.Newslet
 	return &defproto.NewsletterMessage{
 		MessageServerID: proto.Int64(int64(message.MessageServerID)),
 		ViewsCount:      proto.Int64(int64(message.ViewsCount)),
-		Message:         message.Message,
+		Message:         message.Message, // may be nil for deleted messages — field is optional
 		ReactionCounts:  reacts,
 	}
 }
@@ -913,9 +916,12 @@ func EncodeNewsletterMuteChange(mute *events.NewsletterMuteChange) defproto.News
 }
 
 func EncodeNewsletterLiveUpdate(update *events.NewsletterLiveUpdate) defproto.NewsletterLiveUpdate {
-	messages := make([]*defproto.NewsletterMessage, len(update.Messages))
-	for i, message := range update.Messages {
-		messages[i] = EncodeNewsletterMessage(message)
+	messages := make([]*defproto.NewsletterMessage, 0, len(update.Messages))
+	for _, message := range update.Messages {
+		encoded := EncodeNewsletterMessage(message)
+		if encoded != nil {
+			messages = append(messages, encoded)
+		}
 	}
 	return defproto.NewsletterLiveUpdate{
 		JID:      EncodeJidProto(update.JID),

--- a/neonize/aioze/client.py
+++ b/neonize/aioze/client.py
@@ -434,7 +434,6 @@ class ChatSettingsStore:
         return return_.LocalChatSettings
 
 
-
 def _ensure_jid(value: JID | str, server: str = "s.whatsapp.net") -> JID:
     """Coerce a phone-number string into a :class:`JID`.
 

--- a/neonize/client.py
+++ b/neonize/client.py
@@ -386,7 +386,6 @@ class ChatSettingsStore:
         return return_.LocalChatSettings
 
 
-
 def _ensure_jid(value: JID | str, server: str = "s.whatsapp.net") -> JID:
     """Coerce a phone-number string into a :class:`JID`.
 

--- a/neonize/exc.py
+++ b/neonize/exc.py
@@ -22,6 +22,7 @@ everyone else can rely on the common base.
 # Base
 # ---------------------------------------------------------------------------
 
+
 class NeonizeError(Exception):
     """Base class for all neonize-specific errors.
 
@@ -34,8 +35,10 @@ class NeonizeError(Exception):
 # Transport
 # ---------------------------------------------------------------------------
 
+
 class UploadError(NeonizeError):
     """Raised when media upload to WhatsApp servers fails."""
+
 
 class DownloadError(NeonizeError):
     """Raised when media download from WhatsApp servers fails."""
@@ -45,14 +48,18 @@ class DownloadError(NeonizeError):
 # Messaging
 # ---------------------------------------------------------------------------
 
+
 class SendMessageError(NeonizeError):
     """Raised when sending a message fails."""
+
 
 class BuildPollVoteError(NeonizeError):
     """Raised when building a poll vote message fails."""
 
+
 class BuildPollVoteCreationError(NeonizeError):
     """Raised when building a poll creation message fails."""
+
 
 class DecryptPollVoteError(NeonizeError):
     """Raised when decrypting a poll vote fails."""
@@ -62,50 +69,66 @@ class DecryptPollVoteError(NeonizeError):
 # Group
 # ---------------------------------------------------------------------------
 
+
 class CreateGroupError(NeonizeError):
     """Raised when creating a WhatsApp group fails."""
+
 
 class GetGroupInfoError(NeonizeError):
     """Raised when retrieving group information fails."""
 
+
 class GetGroupInviteLinkError(NeonizeError):
     """Raised when retrieving a group invite link fails."""
+
 
 class GetJoinedGroupsError(NeonizeError):
     """Raised when listing joined groups fails."""
 
+
 class GetLinkedGroupParticipantsError(NeonizeError):
     """Raised when retrieving linked group participants fails."""
+
 
 class GetGroupRequestParticipantsError(NeonizeError):
     """Raised when retrieving group join-request participants fails."""
 
+
 class GetSubGroupsError(NeonizeError):
     """Raised when retrieving sub-groups fails."""
+
 
 class JoinGroupWithInviteError(NeonizeError):
     """Raised when joining a group via invite link fails."""
 
+
 class InviteLinkError(NeonizeError):
     """Raised when processing an invite link fails."""
+
 
 class LinkGroupError(NeonizeError):
     """Raised when linking parent/child groups fails."""
 
+
 class UnlinkGroupError(NeonizeError):
     """Raised when unlinking parent/child groups fails."""
+
 
 class SetGroupPhotoError(NeonizeError):
     """Raised when setting a group photo fails."""
 
+
 class SetGroupAnnounceError(NeonizeError):
     """Raised when toggling group announce mode fails."""
+
 
 class SetGroupLockedError(NeonizeError):
     """Raised when toggling group lock fails."""
 
+
 class SetGroupTopicError(NeonizeError):
     """Raised when setting the group topic/description fails."""
+
 
 class UpdateGroupParticipantsError(NeonizeError):
     """Raised when updating group participants (promote/demote/remove) fails."""
@@ -115,38 +138,50 @@ class UpdateGroupParticipantsError(NeonizeError):
 # Newsletter / Channel
 # ---------------------------------------------------------------------------
 
+
 class CreateNewsletterError(NeonizeError):
     """Raised when creating a newsletter/channel fails."""
+
 
 class FollowNewsletterError(NeonizeError):
     """Raised when following a newsletter fails."""
 
+
 class UnfollowNewsletterError(NeonizeError):
     """Raised when unfollowing a newsletter fails."""
+
 
 class GetNewsletterInfoError(NeonizeError):
     """Raised when retrieving newsletter information fails."""
 
+
 class GetNewsletterInfoWithInviteError(NeonizeError):
     """Raised when resolving newsletter info from an invite link fails."""
+
 
 class GetNewsletterMessagesError(NeonizeError):
     """Raised when fetching newsletter messages fails."""
 
+
 class GetNewsletterMessageUpdateError(NeonizeError):
     """Raised when fetching newsletter message updates fails."""
+
 
 class GetSubscribedNewslettersError(NeonizeError):
     """Raised when listing subscribed newsletters fails."""
 
+
 class NewsletterMarkViewedError(NeonizeError):
     """Raised when marking a newsletter message as viewed fails."""
+
 
 class NewsletterSendReactionError(NeonizeError):
     """Raised when sending a reaction to a newsletter message fails."""
 
+
 class NewsletterSubscribeLiveUpdatesError(NeonizeError):
     """Raised when subscribing to newsletter live updates fails."""
+
 
 class NewsletterToggleMuteError(NeonizeError):
     """Raised when toggling newsletter mute state fails."""
@@ -156,32 +191,42 @@ class NewsletterToggleMuteError(NeonizeError):
 # Contact & Profile
 # ---------------------------------------------------------------------------
 
+
 class ContactStoreError(NeonizeError):
     """Raised when a contact store operation fails."""
+
 
 class GetContactQrLinkError(NeonizeError):
     """Raised when retrieving a contact QR link fails."""
 
+
 class GetProfilePictureError(NeonizeError):
     """Raised when retrieving a profile picture fails."""
+
 
 class GetUserInfoError(NeonizeError):
     """Raised when retrieving user information fails."""
 
+
 class GetUserDevicesError(NeonizeError):
     """Raised when listing a user's devices fails."""
+
 
 class GetJIDFromStoreError(NeonizeError):
     """Raised when resolving a JID from the local store fails."""
 
+
 class IsOnWhatsAppError(NeonizeError):
     """Raised when checking WhatsApp registration status fails."""
+
 
 class PairPhoneError(NeonizeError):
     """Raised when pairing via phone number fails."""
 
+
 class ResolveContactQRLinkError(NeonizeError):
     """Raised when resolving a contact QR link fails."""
+
 
 class ResolveBusinessMessageLinkError(NeonizeError):
     """Raised when resolving a business message link fails."""
@@ -191,14 +236,18 @@ class ResolveBusinessMessageLinkError(NeonizeError):
 # Privacy & Status
 # ---------------------------------------------------------------------------
 
+
 class GetBlocklistError(NeonizeError):
     """Raised when retrieving the blocklist fails."""
+
 
 class UpdateBlocklistError(NeonizeError):
     """Raised when updating the blocklist fails."""
 
+
 class GetStatusPrivacyError(NeonizeError):
     """Raised when retrieving status privacy settings fails."""
+
 
 class SetPrivacySettingError(NeonizeError):
     """Raised when changing a privacy setting fails."""
@@ -208,8 +257,10 @@ class SetPrivacySettingError(NeonizeError):
 # Presence & Calls
 # ---------------------------------------------------------------------------
 
+
 class SendPresenceError(NeonizeError):
     """Raised when sending a presence update (typing/composing) fails."""
+
 
 class SubscribePresenceError(NeonizeError):
     """Raised when subscribing to a user's presence fails."""
@@ -219,14 +270,18 @@ class SubscribePresenceError(NeonizeError):
 # Chat Settings
 # ---------------------------------------------------------------------------
 
+
 class GetChatSettingsError(NeonizeError):
     """Raised when retrieving local chat settings fails."""
+
 
 class PutMutedUntilError(NeonizeError):
     """Raised when muting a chat until a specific time fails."""
 
+
 class PutPinnedError(NeonizeError):
     """Raised when pinning/unpinning a chat fails."""
+
 
 class PutArchivedError(NeonizeError):
     """Raised when archiving/unarchiving a chat fails."""
@@ -236,29 +291,38 @@ class PutArchivedError(NeonizeError):
 # State & Misc
 # ---------------------------------------------------------------------------
 
+
 class LogoutError(NeonizeError):
     """Raised when logging out fails."""
+
 
 class MarkReadError(NeonizeError):
     """Raised when marking a message as read fails."""
 
+
 class SendAppStateError(NeonizeError):
     """Raised when sending app state sync fails."""
+
 
 class SetDefaultDisappearingTimerError(NeonizeError):
     """Raised when setting the default disappearing message timer fails."""
 
+
 class SetDisappearingTimerError(NeonizeError):
     """Raised when setting a per-chat disappearing message timer fails."""
+
 
 class SetPassiveError(NeonizeError):
     """Raised when toggling passive mode fails."""
 
+
 class SetStatusMessageError(NeonizeError):
     """Raised when setting the status/about message fails."""
 
+
 class SetProxyAddressError(NeonizeError):
     """Raised when configuring the proxy address fails."""
+
 
 class UnsupportedEvent(NeonizeError):
     """Raised when an unrecognized event code is received from the Go core."""
@@ -280,8 +344,10 @@ class SetGroupNameError(NeonizeError):
 # Media
 # ---------------------------------------------------------------------------
 
+
 class ConvertStickerError(NeonizeError):
     """Raised when converting an image/video to sticker format fails."""
+
 
 class FFProbeError(NeonizeError):
     """Raised when ffprobe fails to analyse a media file."""


### PR DESCRIPTION
Two critical issues where WhatsApp legitimately returns nil values for proto2 fields marked as required, causing uncatachable Go panics that kill the entire Python host process:

Issue #208: UploadNewsletter panics because newsletter media is unencrypted — whatsmeow never sets MediaKey/FileEncSHA256 on the UploadResponse.

Issue #209: GetNewsletterMessages panics when the fetch window contains a deleted channel post with nil Message content.

Changes:
- UploadResponse: MediaKey, FileEncSHA256, FileSHA256 changed from required to optional in Neonize.proto (whatsmeow can omit them)
- NewsletterMessage: Message changed from required to optional (deleted posts have nil content)
- EncodeNewsletterMessage: returns nil for nil input, callers skip nil entries instead of including them in the array
- EncodeNewsletterLiveUpdate: skip nil encoded messages
- GetNewsletterMessages/GetNewsletterMessageUpdate: skip nil messages, check len(NewsletterMessages) > 0 instead of newsletterMessage != nil
- ProtoReturnV3: return empty BytesReturn on marshal error instead of panicking — eliminates the entire class of host-process-killing panics from proto marshaling failures

closes #209 #209 