### PR TITLE
Wrap code snippets in fences and adjust homepage mascot style

### DIFF
--- a/docs/examples/async-bot.md
+++ b/docs/examples/async-bot.md
@@ -10,7 +10,9 @@ Source embedded from
 python examples/async_basic.py
 ```
 
+```python
 --8<-- "examples/async_basic.py"
+```
 
 ## Notes
 

--- a/docs/examples/basic-bot.md
+++ b/docs/examples/basic-bot.md
@@ -19,7 +19,9 @@ Pair with the printed QR code, then send any of the commands handled in the
 
 ## Source
 
+```python
 --8<-- "examples/basic.py"
+```
 
 ## Highlights
 

--- a/docs/examples/interactive-async.md
+++ b/docs/examples/interactive-async.md
@@ -10,7 +10,9 @@ Source embedded from
 python examples/interactive_async.py
 ```
 
+```python
 --8<-- "examples/interactive_async.py"
+```
 
 ## Related Pages
 

--- a/docs/examples/multi-session.md
+++ b/docs/examples/multi-session.md
@@ -10,7 +10,9 @@ Source embedded from
 python examples/multisession_async.py
 ```
 
+```python
 --8<-- "examples/multisession_async.py"
+```
 
 ## Key Ideas
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,8 @@
 # Neonize
 
-<img src="assets/mascot.png" alt="Neonize" style="max-width: 320px" />
+<div align="center">
+<img src="assets/mascot.png" width="15%" alt="Neonize">
+</div>
 
 Neonize is a Python library for WhatsApp automation. A native Go core built on
 [whatsmeow](https://github.com/tulir/whatsmeow) is compiled into a shared


### PR DESCRIPTION
This pull request updates the documentation to improve code example embedding and enhance the visual presentation of the project homepage. The most notable changes include embedding example source code directly into the documentation and updating the main page's mascot image for better alignment and sizing.

Documentation improvements:

* Embedded example source code files directly into their respective documentation pages using the `--8<--` directive, making it easier for users to view and reference the actual code. This change affects `docs/examples/basic-bot.md`, `docs/examples/async-bot.md`, `docs/examples/interactive-async.md`, and `docs/examples/multi-session.md`. [[1]](diffhunk://#diff-25f95265ef46ce85c3d170c23b94fc936da55b58a400f3836332dd6e3f94764bR22-R24) [[2]](diffhunk://#diff-9bf5f7d112aa735dbb31b0582ceb4d9f81b14073a77461d393ad640d274ee105R13-R15) [[3]](diffhunk://#diff-2ee50851cf766835658a63c1be92a67035cad3bbc0fcc2028abce6d1bc9f919eR13-R15) [[4]](diffhunk://#diff-b6b1865dc1b780dce52621d628e9457da0898f8e889462e08330f444ba49ef3bR13-R15)

Homepage visual update:

* Centered the mascot image and set its width to 15% on the main documentation page (`docs/index.md`) for improved appearance and consistency.The `--8<--` pymdownx.snippets directive on four example pages was placed as raw markdown without a surrounding fenced code block, causing the included Python source to render as plain text instead of a highlighted code block. Wrap each include inside ```python fences so the examples display correctly with syntax highlighting.

Also resize and center the homepage mascot to match the tryx docs style.