### PR TITLE
fix(ci): prevent release failure when tag already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,19 +84,32 @@ jobs:
           if [ -z "$NEXT" ]; then
             echo "No release to make."
             echo "release=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "Next version: $NEXT"
-            echo "version=$NEXT" >> "$GITHUB_OUTPUT"
-            echo "tag=$NEXT" >> "$GITHUB_OUTPUT"
-            echo "release=true" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+          # Check if tag already exists — skip if it does
+          if git ls-remote --tags origin | grep -qE "refs/tags/${NEXT}$"; then
+            echo "Tag $NEXT already exists — skipping release."
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Next version: $NEXT"
+          echo "version=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "tag=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "release=true" >> "$GITHUB_OUTPUT"
       - name: Create release commit, tag and GitHub Release
         if: steps.psr.outputs.release == 'true'
         env:
           NEXT: ${{ steps.psr.outputs.version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          uv run semantic-release version
+          # Run PSR for real — commit, tag, push version files
+          PSR_OUTPUT=$(uv run semantic-release version 2>&1) || true
+          echo "$PSR_OUTPUT"
+          # If PSR decided no release, bail out
+          if echo "$PSR_OUTPUT" | grep -q 'No release will be made'; then
+            echo "PSR decided no release — aborting."
+            exit 1
+          fi
           git push origin master
           git push origin "$NEXT"
           gh release create "$NEXT" \


### PR DESCRIPTION
The release workflow's dry-run step (semantic-release --print) could compute a version whose tag already existed on the remote, causing the subsequent gh release create to fail with HTTP 422. Add an explicit tag-existence check in the dry-run step and capture PSR output in the release step to abort early if PSR decides no release is needed.